### PR TITLE
fix: install now throws helpful error when git is either not installe…

### DIFF
--- a/src/install.ts
+++ b/src/install.ts
@@ -1,10 +1,21 @@
 import { copyFileSync } from "fs";
 import { join } from "path";
-import { repoRootDir } from "./git-interop";
+import { GitError, repoRootDir } from "./git-interop";
 
 export function installAsGitHook(): void {
   const commitMsgBinPath = join(__dirname, "commit-msg");
-  const root = repoRootDir();
+
+  let root: string;
+  try {
+    root = repoRootDir();
+  } catch (err) {
+    if (err instanceof GitError) {
+      throw Error(
+        "Could not find the root of the repository -- check that git is installed and that this install is running inside of a git repository."
+      );
+    }
+    throw err;
+  }
   const installPath = join(root, ".git", "hooks", "commit-msg");
   copyFileSync(commitMsgBinPath, installPath);
   console.log(`Installed hook to ${installPath}`);

--- a/test/integration/install.spec.ts
+++ b/test/integration/install.spec.ts
@@ -1,0 +1,11 @@
+import { installAsGitHook } from "../../src/install";
+
+describe("install", () => {
+  describe("installAsGitHook()", () => {
+    it("should throw a helpful error if the install occurs outside of a git repo", () => {
+      expect(() => installAsGitHook()).toThrowError(
+        "Could not find the root of the repository -- check that git is installed and that this install is running inside of a git repository."
+      );
+    });
+  });
+});


### PR DESCRIPTION
…d or the install is running outside of a git repo