### PR TITLE
chore: strict node version support

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ $ git log -1 --pretty=%B
 ### Prerequisites
 
 - [Docker](https://www.docker.com/) installation (for integration and end-to-end (e2e) testing)
-- [Node.js](https://nodejs.org/en/) runtime
+- [Node.js](https://nodejs.org/en/) (>=14.0.0) runtime
 - [Yarn](https://yarnpkg.com/) installation
 
 ### Install Dependencies

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "license": "MIT",
   "author": "Brandon Rajkowski <github@brajkowski.bulc.club>",
   "main": "dist/index.js",
+  "engines": {
+    "node": ">=14.0.0"
+  },
   "bin": {
     "branch-commit-msg": "dist/index.js",
     "branch-commit-msg-hook": "dist/commit-msg"
@@ -39,7 +42,7 @@
   },
   "devDependencies": {
     "@types/jest": "^28.1.6",
-    "@types/node": "^18.6.0",
+    "@types/node": "^16.0.0",
     "@types/yargs": "^17.0.10",
     "@typescript-eslint/eslint-plugin": "^5.30.7",
     "@typescript-eslint/parser": "^5.30.7",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
-    "target": "es2016",
+    "lib": ["ES2020", "ES2021", "ES2022"],
     "module": "commonjs",
+    "target": "es2021",
     "outDir": "./dist",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1112,10 +1112,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.41.tgz#1607b2fd3da014ae5d4d1b31bc792a39348dfb9b"
   integrity sha512-xA6drNNeqb5YyV5fO3OAEsnXLfO7uF0whiOfPTz5AeDo8KeZFmODKnvwPymMNO8qE/an8pVY/O50tig2SQCrGw==
 
-"@types/node@^18.6.0":
-  version "18.6.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.6.0.tgz#3ad8c5a4e8e11abc51a11894355f2ba58de9f1a1"
-  integrity sha512-WZ/6I1GL0DNAo4bb01lGGKTHH8BHJyECepf11kWONg3OJoHq2WYOm16Es1V54Er7NTUXsbDCpKRKdmBc4X2xhA==
+"@types/node@^16.0.0":
+  version "16.11.46"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.46.tgz#26047602eefa47b36759d9ebb1b55ad08ce97a73"
+  integrity sha512-x+sfpb2dMrhCQPL4NAGs64Z9hh0t72aP0dg+PuZidmPr/0Gj5ELQTjD/t46dq3DF/8ZvSHOaIyDIbAsdPshyVQ==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"


### PR DESCRIPTION
* targeting active-LTS (v16)
* supporting current (v18)
* supporting maintenance-LTS (v14)