### PR TITLE
build: npx is the test container script driver

### DIFF
--- a/test/e2e/index.ts
+++ b/test/e2e/index.ts
@@ -6,7 +6,7 @@ const yarnScriptArgs = process.argv.slice(2);
 Object.values(SupportedNodeDockerImage).forEach((dockerImage) => {
   console.log(`Running tests for ${dockerImage}`);
   containerizedTest(
-    "yarn",
+    "npx",
     ["jest", "--testPathPattern=e2e", "-i", ...yarnScriptArgs],
     {
       dockerImage,

--- a/test/integration/index.ts
+++ b/test/integration/index.ts
@@ -6,7 +6,7 @@ const yarnScriptArgs = process.argv.slice(2);
 Object.values(SupportedNodeDockerImage).forEach((dockerImage) => {
   console.log(`Running tests for ${dockerImage}`);
   containerizedTest(
-    "yarn",
+    "npx",
     ["jest", "--testPathPattern=integration", "-i", ...yarnScriptArgs],
     {
       dockerImage,


### PR DESCRIPTION
`yarn` no longer works as the test script driver in the `node:20` Docker image. `corepack` now needs to be enabled to be compatible with the version of `yarn` that this project uses. To avoid this issue, `npx` is now used as the script driver within the test containers.